### PR TITLE
Revert "chore: move substitutefrom to cluster ks"

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -20,6 +20,10 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/cert-manager/cert-manager/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/communication/tuwunel/ks.yaml
+++ b/kubernetes/apps/communication/tuwunel/ks.yaml
@@ -16,6 +16,9 @@ spec:
     substitute:
       APP: tuwunel
       VOLSYNC_CAPACITY: 15Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/download/notifier/ks.yaml
+++ b/kubernetes/apps/download/notifier/ks.yaml
@@ -8,6 +8,9 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/download/notifier/app
   postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/download/sabnzbd/ks.yaml
+++ b/kubernetes/apps/download/sabnzbd/ks.yaml
@@ -19,6 +19,9 @@ spec:
     substitute:
       APP: sabnzbd
       VOLSYNC_CAPACITY: 2Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/download/shelfmark/ks.yaml
+++ b/kubernetes/apps/download/shelfmark/ks.yaml
@@ -11,6 +11,9 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/download/shelfmark/app
   postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
     substitute:
       APP: shelfmark
   prune: true

--- a/kubernetes/apps/download/slskd/ks.yaml
+++ b/kubernetes/apps/download/slskd/ks.yaml
@@ -13,6 +13,9 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/download/slskd/app
   postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
     substitute:
       APP: slskd
       CONTROLLER: StatefulSet

--- a/kubernetes/apps/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/ks.yaml
@@ -9,6 +9,10 @@ spec:
     - name: flux-operator
   interval: 1h
   path: ./kubernetes/apps/flux-system/flux-instance/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/flux-system/flux-operator/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/llm/ollama/ks.yaml
+++ b/kubernetes/apps/llm/ollama/ks.yaml
@@ -13,6 +13,9 @@ spec:
   postBuild:
     substitute:
       APP: ollama
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/llm/open-webui/ks.yaml
+++ b/kubernetes/apps/llm/open-webui/ks.yaml
@@ -18,6 +18,9 @@ spec:
     substitute:
       APP: open-webui
       VOLSYNC_CAPACITY: 5Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/llm/searxng/ks.yaml
+++ b/kubernetes/apps/llm/searxng/ks.yaml
@@ -10,6 +10,10 @@ spec:
       namespace: database
   interval: 1h
   path: ./kubernetes/apps/llm/searxng/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/agregarr/ks.yaml
+++ b/kubernetes/apps/media/agregarr/ks.yaml
@@ -17,6 +17,9 @@ spec:
     substitute:
       APP: agregarr
       VOLSYNC_CAPACITY: 5Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -17,6 +17,9 @@ spec:
     substitute:
       APP: bazarr
       VOLSYNC_CAPACITY: 1Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/bookboss/ks.yaml
+++ b/kubernetes/apps/media/bookboss/ks.yaml
@@ -17,6 +17,9 @@ spec:
     substitute:
       APP: bookboss
       VOLSYNC_CAPACITY: 5Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/lidarr/ks.yaml
+++ b/kubernetes/apps/media/lidarr/ks.yaml
@@ -17,6 +17,9 @@ spec:
     substitute:
       APP: lidarr
       VOLSYNC_CAPACITY: 5Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/owncast/ks.yaml
+++ b/kubernetes/apps/media/owncast/ks.yaml
@@ -18,6 +18,9 @@ spec:
     substitute:
       APP: owncast
       VOLSYNC_CAPACITY: 10Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -19,6 +19,9 @@ spec:
     substitute:
       APP: plex
       VOLSYNC_CAPACITY: 15Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -17,6 +17,9 @@ spec:
     substitute:
       APP: prowlarr
       VOLSYNC_CAPACITY: 1Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -17,6 +17,9 @@ spec:
     substitute:
       APP: radarr
       VOLSYNC_CAPACITY: 5Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -17,6 +17,9 @@ spec:
     substitute:
       APP: seerr
       VOLSYNC_CAPACITY: 5Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -17,6 +17,9 @@ spec:
     substitute:
       APP: sonarr
       VOLSYNC_CAPACITY: 5Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/tautulli/ks.yaml
+++ b/kubernetes/apps/media/tautulli/ks.yaml
@@ -17,6 +17,9 @@ spec:
     substitute:
       APP: tautulli
       VOLSYNC_CAPACITY: 5Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/network/certificates/ks.yaml
+++ b/kubernetes/apps/network/certificates/ks.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/network/certificates/import
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
@@ -25,6 +29,10 @@ spec:
     - name: certificates-import
   interval: 1h
   path: ./kubernetes/apps/network/certificates/export
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/network/cloudflared/ks.yaml
+++ b/kubernetes/apps/network/cloudflared/ks.yaml
@@ -13,6 +13,8 @@ spec:
   postBuild:
     substituteFrom:
       - kind: Secret
+        name: cluster-secrets
+      - kind: Secret
         name: cloudflare-tunnel-id-secret
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/network/echo-server/ks.yaml
+++ b/kubernetes/apps/network/echo-server/ks.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/network/echo-server/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -9,6 +9,10 @@ spec:
     - name: certificates-import
   interval: 1h
   path: ./kubernetes/apps/network/envoy-gateway/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/network/external-dns/ks.yaml
+++ b/kubernetes/apps/network/external-dns/ks.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/network/external-dns/cloudflare
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository
@@ -23,6 +27,10 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/network/external-dns/mikrotik
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/network/unifi/ks.yaml
+++ b/kubernetes/apps/network/unifi/ks.yaml
@@ -17,6 +17,9 @@ spec:
     substitute:
       APP: unifi
       VOLSYNC_CAPACITY: 10Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/observability/blackbox-exporter/ks.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/ks.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/observability/blackbox-exporter/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/observability/gatus/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -27,6 +27,10 @@ spec:
       namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/observability/grafana/instance
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/observability/kromgo/ks.yaml
+++ b/kubernetes/apps/observability/kromgo/ks.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/observability/kromgo/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
@@ -10,6 +10,10 @@ spec:
       namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/observability/kube-prometheus-stack/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/observability/teslamate/ks.yaml
+++ b/kubernetes/apps/observability/teslamate/ks.yaml
@@ -10,6 +10,10 @@ spec:
       namespace: database
   interval: 1h
   path: ./kubernetes/apps/observability/teslamate/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/observability/victoria-logs/ks.yaml
+++ b/kubernetes/apps/observability/victoria-logs/ks.yaml
@@ -10,6 +10,10 @@ spec:
       namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/observability/victoria-logs/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -41,6 +41,10 @@ spec:
       current: status.ceph.health in ['HEALTH_OK', 'HEALTH_WARN']
   interval: 1h
   path: ./kubernetes/apps/rook-ceph/rook-ceph/cluster
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/security/vaultwarden/ks.yaml
+++ b/kubernetes/apps/security/vaultwarden/ks.yaml
@@ -16,6 +16,9 @@ spec:
     substitute:
       APP: vaultwarden
       VOLSYNC_CAPACITY: 1Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/services/home-assistant/ks.yaml
+++ b/kubernetes/apps/services/home-assistant/ks.yaml
@@ -18,6 +18,9 @@ spec:
     substitute:
       APP: home-assistant
       VOLSYNC_CAPACITY: 5Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/services/it-tools/ks.yaml
+++ b/kubernetes/apps/services/it-tools/ks.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/services/it-tools/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/services/karakeep/ks.yaml
+++ b/kubernetes/apps/services/karakeep/ks.yaml
@@ -15,6 +15,9 @@ spec:
   postBuild:
     substitute:
       APP: karakeep
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/services/paperless/ks.yaml
+++ b/kubernetes/apps/services/paperless/ks.yaml
@@ -13,6 +13,9 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/services/paperless/app
   postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
     substitute:
       APP: paperless
   prune: true

--- a/kubernetes/apps/services/wastebin/ks.yaml
+++ b/kubernetes/apps/services/wastebin/ks.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/services/wastebin/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/volsync-system/kopia/ks.yaml
+++ b/kubernetes/apps/volsync-system/kopia/ks.yaml
@@ -14,6 +14,9 @@ spec:
   postBuild:
     substitute:
       APP: kopia
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -28,11 +28,6 @@ spec:
           decryption:
             provider: sops
           deletionPolicy: WaitForTermination
-          postBuild:
-            substituteFrom:
-              - name: cluster-secrets
-                kind: Secret
-                optional: false
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
Reverts phycoforce/home-ops#1901

Turns out you can't have a global substitutefrom and then a local ks substitutefrom. They get overwritten.