### PR TITLE
chore: volsync non-priv

### DIFF
--- a/kubernetes/apps/communication/tuwunel/app/helmrelease.yaml
+++ b/kubernetes/apps/communication/tuwunel/app/helmrelease.yaml
@@ -74,7 +74,19 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 3
               readiness: *probes
-
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
     service:
       main:
         ports:

--- a/kubernetes/apps/llm/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/llm/memini/app/helmrelease.yaml
@@ -17,11 +17,11 @@ spec:
           reloader.stakater.com/auto: "true"
         pod:
           securityContext:
-            fsGroup: 1000
+            fsGroup: 1001
             fsGroupChangePolicy: OnRootMismatch
-            runAsGroup: 1000
+            runAsGroup: 1001
             runAsNonRoot: true
-            runAsUser: 1000
+            runAsUser: 1001
         containers:
           main:
             env:
@@ -64,6 +64,13 @@ spec:
         enabled: true
         cronjob:
           schedule: "0 5 * * *"
+        pod:
+          securityContext:
+            fsGroup: 1001
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
         containers:
           fsck:
             env:

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -51,9 +51,9 @@ spec:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
         fsGroupChangePolicy: OnRootMismatch
     service:
       app:

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -51,9 +51,9 @@ spec:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 568
-        runAsGroup: 568
-        fsGroup: 568
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
         fsGroupChangePolicy: OnRootMismatch
     service:
       app:

--- a/kubernetes/apps/network/unifi/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi/app/helmrelease.yaml
@@ -23,6 +23,12 @@ spec:
                 "ips": ["192.168.0.241/24"],
                 "mac": "48:C3:71:81:39:77"
               }]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            fsGroup: 1001
+            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -30,12 +36,14 @@ spec:
               tag: v10.0.162@sha256:896c0ab82d33300694dae82982fd7094497afcbea0be92cadc1e94bfead731d3
               pullPolicy: IfNotPresent
             env:
-              RUNAS_UID0: "false"
-              UNIFI_UID: "999"
-              UNIFI_GID: "999"
               UNIFI_STDOUT: "true"
               JVM_INIT_HEAP_SIZE:
               JVM_MAX_HEAP_SIZE: 1024M
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
             resources:
               requests:
                 memory: 2Gi

--- a/kubernetes/apps/security/vaultwarden/app/helmrelease.yaml
+++ b/kubernetes/apps/security/vaultwarden/app/helmrelease.yaml
@@ -17,9 +17,9 @@ spec:
         pod:
           securityContext:
             runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
-            fsGroup: 1000
+            runAsUser: 1001
+            runAsGroup: 1001
+            fsGroup: 1001
             fsGroupChangePolicy: OnRootMismatch
             seccompProfile: { type: RuntimeDefault }
         containers:

--- a/kubernetes/apps/services/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/services/home-assistant/app/helmrelease.yaml
@@ -46,9 +46,9 @@ spec:
           }]
       securityContext:
         runAsNonRoot: true
-        runAsUser: 568
-        runAsGroup: 568
-        fsGroup: 568
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
         fsGroupChangePolicy: OnRootMismatch
     persistence:
       config:

--- a/kubernetes/apps/services/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/services/karakeep/app/helmrelease.yaml
@@ -12,10 +12,10 @@ spec:
   values:
     defaultPodOptions:
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 1001
+        runAsGroup: 1001
         runAsNonRoot: true
-        fsGroup: 1000
+        fsGroup: 1001
         fsGroupChangePolicy: "OnRootMismatch"
 
     controllers:

--- a/kubernetes/apps/services/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/services/mealie/app/helmrelease.yaml
@@ -17,9 +17,9 @@ spec:
         pod:
           securityContext:
             runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
-            fsGroup: 1000
+            runAsUser: 1001
+            runAsGroup: 1001
+            fsGroup: 1001
             fsGroupChangePolicy: OnRootMismatch
         containers:
           app:

--- a/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
@@ -4,9 +4,13 @@ apiVersion: volsync.backube/v1alpha1
 kind: KopiaMaintenance
 metadata:
   name: daily
-  namespace: volsync
+  namespace: volsync-system
 spec:
   enabled: true
+  podSecurityContext:
+    runAsUser: 1005
+    runAsGroup: 1005
+    fsGroup: 1005
   trigger:
     schedule: 30 3,15 * * *
   moverVolumes:

--- a/kubernetes/components/namespace/namespace.yaml
+++ b/kubernetes/components/namespace/namespace.yaml
@@ -5,6 +5,5 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-    volsync.backube/privileged-movers: "true"
   labels:
     resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/components/volsync/replicationdestination.yaml
+++ b/kubernetes/components/volsync/replicationdestination.yaml
@@ -22,9 +22,9 @@ spec:
     copyMethod: Snapshot
     enableFileDeletion: true
     moverSecurityContext:
-      runAsUser: ${VOLSYNC_PUID:=1005}
-      runAsGroup: ${VOLSYNC_PGID:=1005}
-      fsGroup: ${VOLSYNC_PGID:=1005}
+      runAsUser: ${VOLSYNC_PUID:=1001}
+      runAsGroup: ${VOLSYNC_PGID:=1001}
+      fsGroup: ${VOLSYNC_PGID:=1001}
     moverVolumes:
       - mountPath: repository
         volumeSource:

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -18,9 +18,9 @@ spec:
     compression: zstd-fastest
     copyMethod: Snapshot
     moverSecurityContext:
-      runAsUser: ${VOLSYNC_PUID:=1005}
-      runAsGroup: ${VOLSYNC_PGID:=1005}
-      fsGroup: ${VOLSYNC_PGID:=1005}
+      runAsUser: ${VOLSYNC_PUID:=1001}
+      runAsGroup: ${VOLSYNC_PGID:=1001}
+      fsGroup: ${VOLSYNC_PGID:=1001}
     moverVolumes:
       - mountPath: repository
         volumeSource:


### PR DESCRIPTION
Standardize everything that uses volsync to 1001:1001. Any applications within this (Unifi and Tuwunel) are set to run as non-root.  Fixed the kopia maintenance job so that it actually uses the correct namespace.

Once merged the following needs addressing: 

Existing volsync-src-<app>-cache PVCs contain root-owned dirs from the privileged era, and fsGroup never changes file owners — so the first unprivileged run would EPERM for all 21 apps, forever. After merging, delete the caches once (they're pure kopia cache and rebuild automatically):

kubectl get pvc -A --no-headers | awk '$2 ~ /^volsync-src-.+-cache$/ {print $1, $2}' \
  | xargs -n2 sh -c 'kubectl delete pvc -n "$0" "$1"'