### PR TITLE
chore(renovate-config)!: update config home-operations/renovate-presets (5.0.0 ➔ 7.0.0)

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,7 +1,10 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "github>home-operations/renovate-presets#5.0.0",
+    "github>home-operations/renovate-presets#7.0.0",
+    "github>home-operations/renovate-presets//apps/grafanaDashboards.json5#7.0.0",
+    "github>home-operations/renovate-presets//apps/llamacpp.json5#7.0.0",
+    "github>home-operations/renovate-presets//apps/talosFactory.json5#7.0.0",
     "github>phycoforce/home-ops//.renovate/allowedVersions.json5",
     "github>phycoforce/home-ops//.renovate/autoMerge.json5",
     "github>phycoforce/home-ops//.renovate/groups.json5",


### PR DESCRIPTION
The #5.0.0 pin only pinned the entry point: default.json at that tag references its nested presets untagged, so Renovate resolves them from the preset repo's default branch. renovate-presets 6.0.0 moved the app-specific presets into an opt-in apps/ directory, so the pinned default.json kept asking for paths that no longer exist on main and preset resolution halted every PR (#2636).

Bump to 7.0.0, whose default.json inlines all general-purpose presets (no more nested references that can drift), and opt into the apps/ presets this repo actually uses:

- apps/grafanaDashboards.json5: grafana.com revision pins in grafanadashboard.yaml manifests, and defines the custom.grafana-dashboards datasource our auto-merge rule matches.
- apps/llamacpp.json5: variant-aware versioning for the ghcr.io/ggml-org/llama.cpp server-vulkan-b* tags used by llmkube.
- apps/talosFactory.json5: the factory.talos.dev installer image in talos/machineconfig.yaml.j2, and defines the custom.talos-factory datasource the tuppr TalosUpgrade annotation depends on.

cnpg, phanpy and searxng also moved but are unused here: the PostgreSQL pin is an annotated Flux variable already covered by the default annotated-deps manager, and the other two images are not deployed.

Closes #2636
